### PR TITLE
Bind: support Rocky Linux 9

### DIFF
--- a/roles/bind/vars/rocky.yml
+++ b/roles/bind/vars/rocky.yml
@@ -1,0 +1,27 @@
+---
+
+bind_packages:
+  - python3-netaddr
+  - python3-dns
+  - bind
+  - bind-utils
+  - bind-dnssec-utils
+
+bind_service: named
+
+# Main config file
+bind_config: /etc/named.conf
+
+# Localhost zone
+bind_default_zone_files:
+  - /etc/named.rfc1912.zones
+
+# Directory with run-time stuff
+bind_dir: /var/named
+bind_conf_dir: "{{ bind_dir }}"
+bind_auth_file: "{{ bind_conf_dir }}/auth_transfer.conf"
+
+bind_owner: root
+bind_group: named
+
+...


### PR DESCRIPTION
This PR adds a variable file for Rocky Linux 9. Support for RHEL 9 or other RHEL 9 derivatives should be easy to add by renaming or copying the file, but this has not been tested.