### PR TITLE
add bind_update_keys for support of DDNS updates

### DIFF
--- a/roles/bind/README.md
+++ b/roles/bind/README.md
@@ -19,6 +19,12 @@ bind_dns_keys: []
 #    algorithm: hmac-sha256
 #    secret: "azertyAZERTY123456"
 
+# Key binding for DDNS hosts
+bind_update_keys: []
+#  - name: ddns_host_key
+#    algorithm: hmac-sha256
+#    secret: "azertyAZERTY123456"
+
 # List of IPv4 address of the network interface(s) to listen on. Set to "any"
 # to listen on all interfaces
 bind_listen:

--- a/roles/bind/defaults/main.yml
+++ b/roles/bind/defaults/main.yml
@@ -12,6 +12,12 @@ bind_dns_keys: []
 #    algorithm: hmac-sha256
 #    secret: "azertyAZERTY123456"
 
+# Key binding for DDNS updates
+bind_update_keys: []
+#  - name: update_key
+#    algorithm: hmac-sha256
+#    secret: "azertyAZERTY123456"
+
 # List of IPv4 address of the network interface(s) to listen on. Set to "any"
 # to listen on all interfaces
 bind_listen:

--- a/roles/bind/tasks/configure/main.yml
+++ b/roles/bind/tasks/configure/main.yml
@@ -56,6 +56,22 @@
   tags:
     - bind
 
+- name: create extra config for authenticated DDNS updates
+  become: true
+  ansible.builtin.template:
+    src: etc/auth_update.j2
+    dest: "{{ bind_auth_update_file }}"
+    owner: root
+    group: "{{ bind_group }}"
+    mode: '0640'
+  when:
+    - bind_update_keys is defined
+    - bind_update_keys | length > 0
+  notify:
+    - reload bind
+  tags:
+    - bind
+
 - name: configure
   ansible.builtin.include_tasks: configure/zones.yml
 

--- a/roles/bind/templates/etc/auth_update.j2
+++ b/roles/bind/templates/etc/auth_update.j2
@@ -1,0 +1,13 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
+# Authentication definitions to allow DDNS update
+#
+# Copyright 2025 Buo-ren Lin <buo.ren.lin@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# {{ ansible_managed }}
+{% for mykey in bind_update_keys %}
+key {{ mykey.name }} {
+  algorithm {{ mykey.algorithm }};
+  secret "{{ mykey.secret }}";
+};
+{% endfor %}

--- a/roles/bind/vars/main.yml
+++ b/roles/bind/vars/main.yml
@@ -22,6 +22,7 @@ bind_default_zone_files:
 bind_dir: /var/cache/bind
 bind_conf_dir: "/etc/bind"
 bind_auth_file: "{{ bind_conf_dir }}/auth_transfer.conf"
+bind_auth_update_file: "{{ bind_conf_dir }}/auth_update.conf"
 
 bind_owner: root
 bind_group: bind


### PR DESCRIPTION
This pull request introduces the `bind_update_keys` variable to configure TSIG keys for DDNS hosts to issue update requests to the primary authoritative server, which helps prevent address spoofing attacks.