### PR TITLE
AI: bind: handle dynamic zone files safely

### DIFF
--- a/plugins/module_utils/bind_zone/builder.py
+++ b/plugins/module_utils/bind_zone/builder.py
@@ -110,6 +110,7 @@ class ZoneSpecBuilder:
             zone_type=zone_type,
             allow_update_present=bool(raw_zone.get("allow_update")),
         )
+        dynamic_updates = self._is_dynamic_zone(raw_zone)
 
         definitions: list[ZoneDefinitionSpec] = []
         files: list[ZoneFileSpec] = []
@@ -137,6 +138,7 @@ class ZoneSpecBuilder:
                         zone_name=zone_name,
                         zone_type=zone_type,
                         state=state,
+                        dynamic_updates=dynamic_updates,
                     )
                 )
 
@@ -167,6 +169,7 @@ class ZoneSpecBuilder:
                             zone_type=zone_type,
                             state=state,
                             network=network,
+                            dynamic_updates=dynamic_updates,
                         )
                     )
 
@@ -198,6 +201,7 @@ class ZoneSpecBuilder:
                             zone_type=zone_type,
                             state=state,
                             network=network,
+                            dynamic_updates=dynamic_updates,
                         )
                     )
 
@@ -345,6 +349,7 @@ class ZoneSpecBuilder:
         zone_name: str,
         zone_type: str,
         state: str,
+        dynamic_updates: bool,
     ) -> ZoneFileSpec:
         """Build the canonical forward zone file model."""
         records = ()
@@ -362,6 +367,7 @@ class ZoneSpecBuilder:
             family="none",
             filename=zone_name,
             origin=self._ensure_trailing_dot(zone_name),
+            dynamic_updates=dynamic_updates,
             records=records,
         )
 
@@ -372,6 +378,7 @@ class ZoneSpecBuilder:
         zone_type: str,
         state: str,
         network: IPv4Network,
+        dynamic_updates: bool,
     ) -> ZoneFileSpec:
         """Build one canonical IPv4 reverse zone file model."""
         filename = self._ipv4_reverse_zone_name(network)
@@ -391,6 +398,7 @@ class ZoneSpecBuilder:
             filename=filename,
             origin=self._ensure_trailing_dot(filename),
             network=network.with_prefixlen,
+            dynamic_updates=dynamic_updates,
             records=records,
         )
 
@@ -401,6 +409,7 @@ class ZoneSpecBuilder:
         zone_type: str,
         state: str,
         network: IPv6Network,
+        dynamic_updates: bool,
     ) -> ZoneFileSpec:
         """Build one canonical IPv6 reverse zone file model."""
         filename = self._ipv6_reverse_zone_name(network)
@@ -420,7 +429,15 @@ class ZoneSpecBuilder:
             filename=filename,
             origin=self._ensure_trailing_dot(filename),
             network=network.with_prefixlen,
+            dynamic_updates=dynamic_updates,
             records=records,
+        )
+
+    def _is_dynamic_zone(self, raw_zone: Mapping[str, Any]) -> bool:
+        """Return True when a zone is configured for dynamic updates."""
+        return any(
+            self._has_non_empty_value(raw_zone.get(field))
+            for field in ("allow_updates", "allow_update", "update_policy")
         )
 
     def _build_forward_records(

--- a/plugins/module_utils/bind_zone/cache.py
+++ b/plugins/module_utils/bind_zone/cache.py
@@ -46,6 +46,7 @@ class ZoneFileCacheStore:
             kind=spec.kind,
             family=spec.family,
             network=spec.network,
+            dynamic_updates=spec.dynamic_updates,
             content_sha256=content_sha256,
         )
         payload = {

--- a/plugins/module_utils/bind_zone/models.py
+++ b/plugins/module_utils/bind_zone/models.py
@@ -101,6 +101,7 @@ class ZoneFileSpec:
     filename: str
     origin: str
     network: str | None = None
+    dynamic_updates: bool = False
     default_ttl: int = 86400
     records: tuple[ZoneRecord, ...] = field(default_factory=tuple)
 
@@ -151,6 +152,7 @@ class ZoneFileCacheEntry:
     kind: ZoneFileKind
     family: AddressFamily
     network: str | None = None
+    dynamic_updates: bool = False
     content_sha256: str | None = None
 
 
@@ -168,3 +170,4 @@ class ReconcileResult:
 
     changed: bool
     changes: tuple[ZoneFileChange, ...] = field(default_factory=tuple)
+    dynamic_to_static_zones: tuple[str, ...] = field(default_factory=tuple)

--- a/plugins/module_utils/bind_zone/reconciler.py
+++ b/plugins/module_utils/bind_zone/reconciler.py
@@ -257,6 +257,7 @@ class ZoneFileReconciler:
         """Return whether a previously dynamic managed zone is now static."""
         return (
             cache_entry is not None
+            and cache_entry.source_zone_name == zone_file.source_zone_name
             and cache_entry.dynamic_updates
             and not zone_file.dynamic_updates
             and zone_file.state == "present"

--- a/plugins/module_utils/bind_zone/reconciler.py
+++ b/plugins/module_utils/bind_zone/reconciler.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .cache import ZoneFileCacheStore
-from .models import ReconcileResult, ZoneFileChange, ZoneFileSpec
+from .models import ReconcileResult, ZoneFileCacheEntry, ZoneFileChange, ZoneFileSpec
 from .reader import ZoneFileReader
 from .renderer import ZoneFileRenderer
 from .serials import SerialNumberService
@@ -59,12 +59,21 @@ class ZoneFileReconciler:
 
         desired_by_key = {zone_file.key: zone_file for zone_file in zone_files}
         cache_entries = self._cache_store.read_all()
+        dynamic_to_static_zones = tuple(
+            zone_file.origin.removesuffix(".")
+            for zone_file in zone_files
+            if self._is_dynamic_to_static_transition(
+                zone_file=zone_file,
+                cache_entry=cache_entries.get(zone_file.key),
+            )
+        )
 
         changes: list[ZoneFileChange] = []
         for zone_file in zone_files:
             changes.append(
                 self._reconcile_one(
                     zone_file=zone_file,
+                    cache_entry=cache_entries.get(zone_file.key),
                     serial_strategy=serial_strategy,
                     check_mode=check_mode,
                     file_mode=file_mode,
@@ -87,12 +96,17 @@ class ZoneFileReconciler:
                 )
 
         changed = any(item.changed for item in changes)
-        return ReconcileResult(changed=changed, changes=tuple(changes))
+        return ReconcileResult(
+            changed=changed,
+            changes=tuple(changes),
+            dynamic_to_static_zones=dynamic_to_static_zones,
+        )
 
     def _reconcile_one(
         self,
         *,
         zone_file: ZoneFileSpec,
+        cache_entry: ZoneFileCacheEntry | None,
         serial_strategy: str,
         check_mode: bool,
         file_mode: int | None,
@@ -104,6 +118,12 @@ class ZoneFileReconciler:
         """Reconcile one desired zone file."""
         target_path = self._zone_directory / zone_file.filename
         current_state = self._reader.read(str(target_path))
+        journal_removed = self._remove_journal_for_dynamic_to_static_transition(
+            zone_file=zone_file,
+            cache_entry=cache_entry,
+            target_path=target_path,
+            check_mode=check_mode,
+        )
 
         if zone_file.state == "absent":
             removed = False
@@ -126,6 +146,25 @@ class ZoneFileReconciler:
                 changed=changed,
                 old_serial=current_state.serial,
                 new_serial=None,
+            )
+
+        if zone_file.dynamic_updates and current_state.exists:
+            if not check_mode:
+                content_sha256 = None
+                if current_state.content is not None:
+                    content_sha256 = hashlib.sha256(
+                        current_state.content.encode("utf-8")
+                    ).hexdigest()
+                self._cache_store.write(zone_file, content_sha256=content_sha256)
+
+            cache_missing = cache_entry is None
+            return ZoneFileChange(
+                key=zone_file.key,
+                filename=zone_file.filename,
+                action="unchanged",
+                changed=(cache_missing and not check_mode) or journal_removed,
+                old_serial=current_state.serial,
+                new_serial=current_state.serial,
             )
 
         rendered_compare = self._renderer.normalize_rendered_content(
@@ -185,6 +224,42 @@ class ZoneFileReconciler:
             new_serial=next_serial,
             diff_before=current_state.content if include_diff else None,
             diff_after=rendered_compare if include_diff else None,
+        )
+
+    def _remove_journal_for_dynamic_to_static_transition(
+        self,
+        *,
+        zone_file: ZoneFileSpec,
+        cache_entry: ZoneFileCacheEntry | None,
+        target_path: Path,
+        check_mode: bool,
+    ) -> bool:
+        """Discard the journal when a previously dynamic zone becomes static."""
+        converting_to_static = self._is_dynamic_to_static_transition(
+            zone_file=zone_file,
+            cache_entry=cache_entry,
+        )
+        journal_path = target_path.with_name(f"{target_path.name}.jnl")
+
+        if not converting_to_static or not journal_path.exists():
+            return False
+
+        if not check_mode:
+            journal_path.unlink()
+        return True
+
+    def _is_dynamic_to_static_transition(
+        self,
+        *,
+        zone_file: ZoneFileSpec,
+        cache_entry: ZoneFileCacheEntry | None,
+    ) -> bool:
+        """Return whether a previously dynamic managed zone is now static."""
+        return (
+            cache_entry is not None
+            and cache_entry.dynamic_updates
+            and not zone_file.dynamic_updates
+            and zone_file.state == "present"
         )
 
     def _purge_stale_entry(

--- a/plugins/modules/bind_zone_files.py
+++ b/plugins/modules/bind_zone_files.py
@@ -115,6 +115,12 @@ changes:
   returned: always
   type: list
   elements: dict
+dynamic_to_static_zones:
+  description:
+    - Zone names that were dynamic on the preceding managed run and are now static.
+  returned: always
+  type: list
+  elements: str
 zone_files:
   description: Canonical zone file specs built from the raw input.
   returned: always
@@ -167,6 +173,9 @@ class BindZoneFilesModule:
 
         return {
             "changed": reconcile_result.changed,
+            "dynamic_to_static_zones": list(
+                reconcile_result.dynamic_to_static_zones
+            ),
             "zone_files": [asdict(item) for item in build_result.zone_files],
             "zone_definitions": [
                 asdict(item) for item in build_result.zone_definitions

--- a/roles/bind/README.md
+++ b/roles/bind/README.md
@@ -383,6 +383,19 @@ jede Regel hat mindestens:
 ```
 
 
+## Dynamic zone management
+
+Primary zones configured with a non-empty `allow_updates` or `update_policy`
+are dynamic. The role creates a missing dynamic zone file, then leaves the file
+and its BIND journal unchanged on later runs so DDNS records survive.
+
+When a zone managed as dynamic on the preceding role run is changed to static,
+the role intentionally drops its DDNS state. It freezes the zone, deletes its
+journal, renders a new zone file containing only the records declared in
+`bind_zones`, installs the static BIND configuration, and reloads BIND. Run the
+role at least once with the zone configured as dynamic before converting it so
+the role's cache can identify the transition.
+
 ## Contribution
 
 Please read [Contribution](CONTRIBUTING.md)

--- a/roles/bind/tasks/configure/main.yml
+++ b/roles/bind/tasks/configure/main.yml
@@ -72,9 +72,6 @@
   tags:
     - bind
 
-- name: configure
-  ansible.builtin.include_tasks: configure/zones.yml
-
 - name: detect default zone files
   bodsch.core.find_files:
     file_list: "{{ bind_default_zone_files }}"
@@ -86,17 +83,42 @@
   ansible.builtin.set_fact:
     bind_default_zone_files: "{{ file_check.stat | selectattr('exists') | map(attribute='path') | list }}"
 
-- name: create main bind config file {{ bind_config }}
-  become: true
-  ansible.builtin.template:
-    src: etc/named.conf.j2
-    dest: "{{ bind_config }}"
-    owner: "{{ bind_owner }}"
-    group: "{{ bind_group }}"
-    mode: "0640"
-    backup: true
-    validate: 'named-checkconf %s'
-  notify:
-    - reload bind
+- name: reconcile zone files and configuration
+  block:
+    - name: configure zone files
+      ansible.builtin.include_tasks: configure/zones.yml
+
+    - name: create main bind config file {{ bind_config }}
+      become: true
+      ansible.builtin.template:
+        src: etc/named.conf.j2
+        dest: "{{ bind_config }}"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "0640"
+        backup: true
+        validate: 'named-checkconf %s'
+      notify:
+        - reload bind
+
+    - name: apply dynamic to static zone transitions
+      ansible.builtin.meta: flush_handlers
+      when:
+        - bind_zone_file_plan.dynamic_to_static_zones | length > 0
+
+  rescue:
+    - name: thaw zones after a failed dynamic to static transition
+      become: true
+      ansible.builtin.command:
+        cmd: "rndc thaw {{ item }}"
+      loop: "{{ bind_zone_file_plan.dynamic_to_static_zones | default([]) }}"
+      changed_when: true
+      failed_when: false
+
+    - name: report failed zone transition
+      ansible.builtin.fail:
+        msg: >-
+          Failed to reconcile BIND zone files and configuration:
+          {{ ansible_failed_result.msg | default(ansible_failed_result) }}
 
 ...

--- a/roles/bind/tasks/configure/zones.yml
+++ b/roles/bind/tasks/configure/zones.yml
@@ -12,7 +12,25 @@
     host_all_addresses: "{{ ansible_facts.all_ipv4_addresses | union(ansible_facts.all_ipv6_addresses) }}"
   tags: bind
 
+- name: plan bind zone file changes
+  become: true
+  bodsch.dns.bind_zone_files:
+    zones: "{{ bind_zones }}"
+    zone_directory: "{{ bind_zone_dir }}"
+    serial_strategy: "increment"
+  check_mode: true
+  changed_when: false
+  register: bind_zone_file_plan
+
+- name: freeze dynamic zones being converted to static
+  become: true
+  ansible.builtin.command:
+    cmd: "rndc freeze {{ item }}"
+  loop: "{{ bind_zone_file_plan.dynamic_to_static_zones }}"
+  changed_when: true
+
 - name: create bind zone files
+  become: true
   bodsch.dns.bind_zone_files:
     zones: "{{ bind_zones }}"
     zone_directory: "{{ bind_zone_dir }}"

--- a/tests/unit/test_bind_zone_reconciler.py
+++ b/tests/unit/test_bind_zone_reconciler.py
@@ -274,6 +274,73 @@ def test_reconciler_drops_ddns_records_when_zone_becomes_static(
     assert journal_file.exists() is False
 
 
+def test_reconciler_does_not_transition_reassigned_reverse_zone(
+    tmp_path: Path,
+) -> None:
+    models_mod = _load_bind_zone_module("models")
+    reconciler_mod = _load_bind_zone_module("reconciler")
+
+    zone_dir = tmp_path / "zones"
+    cache_dir = tmp_path / "cache"
+    zone_dir.mkdir()
+    cache_dir.mkdir()
+
+    zone_file = zone_dir / "3.168.192.in-addr.arpa"
+    journal_file = zone_dir / "3.168.192.in-addr.arpa.jnl"
+    zone_file.write_text("EXISTING REVERSE ZONE\n", encoding="utf-8")
+    journal_file.write_text("JOURNAL FROM UNKNOWN LIVE STATE\n", encoding="utf-8")
+
+    cached_dynamic_spec = models_mod.ZoneFileSpec(
+        key="reverse:ipv4:192.168.3.0/24",
+        source_zone_name="ddns.example",
+        state="present",
+        zone_type="primary",
+        kind="reverse",
+        family="ipv4",
+        filename="3.168.192.in-addr.arpa",
+        origin="3.168.192.in-addr.arpa.",
+        network="192.168.3.0/24",
+        dynamic_updates=True,
+        records=(),
+    )
+    desired_static_spec = models_mod.ZoneFileSpec(
+        key="reverse:ipv4:192.168.3.0/24",
+        source_zone_name="infra.example",
+        state="present",
+        zone_type="primary",
+        kind="reverse",
+        family="ipv4",
+        filename="3.168.192.in-addr.arpa",
+        origin="3.168.192.in-addr.arpa.",
+        network="192.168.3.0/24",
+        records=(
+            models_mod.ZoneRecord(
+                owner="@",
+                rtype="NS",
+                value="ns1.infra.example.",
+            ),
+            models_mod.ZoneRecord(
+                owner="1",
+                rtype="PTR",
+                value="router.infra.example.",
+            ),
+        ),
+    )
+
+    reconciler = reconciler_mod.ZoneFileReconciler(
+        zone_directory=str(zone_dir),
+        cache_directory=str(cache_dir),
+    )
+    reconciler.reconcile((cached_dynamic_spec,))
+
+    plan = reconciler.reconcile((desired_static_spec,), check_mode=True)
+
+    assert plan.dynamic_to_static_zones == ()
+    assert journal_file.read_text(encoding="utf-8") == (
+        "JOURNAL FROM UNKNOWN LIVE STATE\n"
+    )
+
+
 def test_reconciler_keeps_journal_for_dynamic_zone(tmp_path: Path) -> None:
     models_mod = _load_bind_zone_module("models")
     reconciler_mod = _load_bind_zone_module("reconciler")

--- a/tests/unit/test_bind_zone_reconciler.py
+++ b/tests/unit/test_bind_zone_reconciler.py
@@ -1,0 +1,311 @@
+"""Unit tests for bind_zone dynamic/static reconciliation behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_bind_zone_module(module_name: str):
+    """Load a bind_zone module from this workspace without installation."""
+    repo_root = Path(__file__).resolve().parents[2]
+    bind_zone_dir = repo_root / "plugins" / "module_utils" / "bind_zone"
+
+    package_name = "bind_zone"
+    if package_name not in sys.modules:
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(bind_zone_dir)]
+        sys.modules[package_name] = package
+
+    full_name = f"{package_name}.{module_name}"
+    if full_name in sys.modules:
+        return sys.modules[full_name]
+
+    module_path = bind_zone_dir / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(full_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load module spec for {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_builder_marks_dynamic_zone_files() -> None:
+    builder_mod = _load_bind_zone_module("builder")
+
+    builder = builder_mod.ZoneSpecBuilder()
+    result = builder.build(
+        [
+            {
+                "name": "dynamic.example",
+                "type": "primary",
+                "allow_updates": ["10.0.1.2"],
+                "name_servers": ["ns1.dynamic.example."],
+                "hosts": [{"name": "ns1", "ip": "10.0.1.10"}],
+            },
+            {
+                "name": "static.example",
+                "type": "primary",
+                "name_servers": ["ns1.static.example."],
+                "hosts": [{"name": "ns1", "ip": "10.0.2.10"}],
+            },
+        ]
+    )
+
+    zone_by_name = {item.source_zone_name: item for item in result.zone_files}
+    assert zone_by_name["dynamic.example"].dynamic_updates is True
+    assert zone_by_name["static.example"].dynamic_updates is False
+
+
+def test_builder_marks_update_policy_zone_files_as_dynamic() -> None:
+    builder_mod = _load_bind_zone_module("builder")
+
+    result = builder_mod.ZoneSpecBuilder().build(
+        [
+            {
+                "name": "dynamic.example",
+                "type": "primary",
+                "update_policy": {"mode": "local"},
+                "name_servers": ["ns1.dynamic.example."],
+                "hosts": [{"name": "ns1", "ip": "10.0.1.10"}],
+            }
+        ]
+    )
+
+    assert all(zone_file.dynamic_updates for zone_file in result.zone_files)
+
+
+def test_reconciler_keeps_existing_dynamic_zone_file(tmp_path: Path) -> None:
+    models_mod = _load_bind_zone_module("models")
+    reconciler_mod = _load_bind_zone_module("reconciler")
+
+    zone_dir = tmp_path / "zones"
+    cache_dir = tmp_path / "cache"
+    zone_dir.mkdir()
+    cache_dir.mkdir()
+
+    zone_file = zone_dir / "dynamic.example"
+    original_content = "ORIGINAL_DYNAMIC_CONTENT\n"
+    zone_file.write_text(original_content, encoding="utf-8")
+
+    spec = models_mod.ZoneFileSpec(
+        key="forward:dynamic.example",
+        source_zone_name="dynamic.example",
+        state="present",
+        zone_type="primary",
+        kind="forward",
+        family="none",
+        filename="dynamic.example",
+        origin="dynamic.example.",
+        dynamic_updates=True,
+        records=(),
+    )
+
+    reconciler = reconciler_mod.ZoneFileReconciler(
+        zone_directory=str(zone_dir),
+        cache_directory=str(cache_dir),
+    )
+
+    first = reconciler.reconcile((spec,))
+    assert first.changes[0].action == "unchanged"
+    assert zone_file.read_text(encoding="utf-8") == original_content
+
+    second = reconciler.reconcile((spec,))
+    assert second.changed is False
+    assert second.changes[0].action == "unchanged"
+    assert zone_file.read_text(encoding="utf-8") == original_content
+
+
+def test_reconciler_creates_missing_dynamic_zone_file(tmp_path: Path) -> None:
+    models_mod = _load_bind_zone_module("models")
+    reconciler_mod = _load_bind_zone_module("reconciler")
+
+    zone_dir = tmp_path / "zones"
+    cache_dir = tmp_path / "cache"
+    zone_dir.mkdir()
+    cache_dir.mkdir()
+
+    spec = models_mod.ZoneFileSpec(
+        key="forward:dynamic.example",
+        source_zone_name="dynamic.example",
+        state="present",
+        zone_type="primary",
+        kind="forward",
+        family="none",
+        filename="dynamic.example",
+        origin="dynamic.example.",
+        dynamic_updates=True,
+        records=(
+            models_mod.ZoneRecord(
+                owner="@",
+                rtype="NS",
+                value="ns1.dynamic.example.",
+            ),
+        ),
+    )
+
+    reconciler = reconciler_mod.ZoneFileReconciler(
+        zone_directory=str(zone_dir),
+        cache_directory=str(cache_dir),
+    )
+
+    result = reconciler.reconcile((spec,))
+    assert result.changed is True
+    assert result.changes[0].action == "created"
+    assert (zone_dir / "dynamic.example").exists()
+
+
+def test_reconciler_does_not_manage_journal_files(tmp_path: Path) -> None:
+    models_mod = _load_bind_zone_module("models")
+    reconciler_mod = _load_bind_zone_module("reconciler")
+
+    zone_dir = tmp_path / "zones"
+    cache_dir = tmp_path / "cache"
+    zone_dir.mkdir()
+    cache_dir.mkdir()
+
+    zone_file = zone_dir / "static.example"
+    journal_file = zone_dir / "static.example.jnl"
+    zone_file.write_text("OLD STATIC CONTENT\n", encoding="utf-8")
+    journal_file.write_text("BIND-OWNED JOURNAL\n", encoding="utf-8")
+
+    spec = models_mod.ZoneFileSpec(
+        key="forward:static.example",
+        source_zone_name="static.example",
+        state="present",
+        zone_type="primary",
+        kind="forward",
+        family="none",
+        filename="static.example",
+        origin="static.example.",
+        records=(
+            models_mod.ZoneRecord(
+                owner="@",
+                rtype="NS",
+                value="ns1.static.example.",
+            ),
+        ),
+    )
+
+    result = reconciler_mod.ZoneFileReconciler(
+        zone_directory=str(zone_dir),
+        cache_directory=str(cache_dir),
+    ).reconcile((spec,))
+
+    assert result.changes[0].action == "updated"
+    assert journal_file.read_text(encoding="utf-8") == "BIND-OWNED JOURNAL\n"
+
+
+def test_reconciler_drops_ddns_records_when_zone_becomes_static(
+    tmp_path: Path,
+) -> None:
+    models_mod = _load_bind_zone_module("models")
+    reconciler_mod = _load_bind_zone_module("reconciler")
+
+    zone_dir = tmp_path / "zones"
+    cache_dir = tmp_path / "cache"
+    zone_dir.mkdir()
+    cache_dir.mkdir()
+
+    zone_file = zone_dir / "transition.example"
+    journal_file = zone_dir / "transition.example.jnl"
+    zone_file.write_text(
+        "DECLARED AND DDNS RECORDS\n",
+        encoding="utf-8",
+    )
+    journal_file.write_text("DDNS JOURNAL\n", encoding="utf-8")
+
+    dynamic_spec = models_mod.ZoneFileSpec(
+        key="forward:transition.example",
+        source_zone_name="transition.example",
+        state="present",
+        zone_type="primary",
+        kind="forward",
+        family="none",
+        filename="transition.example",
+        origin="transition.example.",
+        dynamic_updates=True,
+        records=(),
+    )
+    static_spec = models_mod.ZoneFileSpec(
+        key="forward:transition.example",
+        source_zone_name="transition.example",
+        state="present",
+        zone_type="primary",
+        kind="forward",
+        family="none",
+        filename="transition.example",
+        origin="transition.example.",
+        records=(
+            models_mod.ZoneRecord(
+                owner="@",
+                rtype="NS",
+                value="ns1.transition.example.",
+            ),
+            models_mod.ZoneRecord(
+                owner="ns1",
+                rtype="A",
+                value="192.0.2.53",
+            ),
+        ),
+    )
+
+    reconciler = reconciler_mod.ZoneFileReconciler(
+        zone_directory=str(zone_dir),
+        cache_directory=str(cache_dir),
+    )
+    reconciler.reconcile((dynamic_spec,))
+
+    plan = reconciler.reconcile((static_spec,), check_mode=True)
+    assert plan.dynamic_to_static_zones == ("transition.example",)
+    assert journal_file.exists() is True
+
+    result = reconciler.reconcile((static_spec,))
+
+    rendered = zone_file.read_text(encoding="utf-8")
+    assert result.dynamic_to_static_zones == ("transition.example",)
+    assert result.changes[0].action == "updated"
+    assert "DECLARED AND DDNS RECORDS" not in rendered
+    assert "192.0.2.53" in rendered
+    assert journal_file.exists() is False
+
+
+def test_reconciler_keeps_journal_for_dynamic_zone(tmp_path: Path) -> None:
+    models_mod = _load_bind_zone_module("models")
+    reconciler_mod = _load_bind_zone_module("reconciler")
+
+    zone_dir = tmp_path / "zones"
+    cache_dir = tmp_path / "cache"
+    zone_dir.mkdir()
+    cache_dir.mkdir()
+
+    zone_file = zone_dir / "dynamic.example"
+    journal_file = zone_dir / "dynamic.example.jnl"
+    zone_file.write_text("DYNAMIC\n", encoding="utf-8")
+    journal_file.write_text("journal", encoding="utf-8")
+
+    spec = models_mod.ZoneFileSpec(
+        key="forward:dynamic.example",
+        source_zone_name="dynamic.example",
+        state="present",
+        zone_type="primary",
+        kind="forward",
+        family="none",
+        filename="dynamic.example",
+        origin="dynamic.example.",
+        dynamic_updates=True,
+        records=(),
+    )
+
+    reconciler = reconciler_mod.ZoneFileReconciler(
+        zone_directory=str(zone_dir),
+        cache_directory=str(cache_dir),
+    )
+
+    result = reconciler.reconcile((spec,))
+    assert result.changes[0].action == "unchanged"
+    assert journal_file.exists() is True


### PR DESCRIPTION
**Content warning:** This pull request is _mostly_ vibe-coded, while I do test it as much as I can, I not capable of fully validate and endorse it at the moment.  _Feel free to drop it if it is not salvageable._

---

BIND periodically writes dynamically updated zone data back to the master file in its own format. This removes the role's "; Hash:" marker, which associates the rendered content with its SOA serial.

On the next role run, the missing marker causes a new serial to be generated. Replacing the master file while retaining the existing journal leaves the file serial outside the journal's history. BIND then refuses to load the zone after a restart with "journal out of sync with zone". Re-rendering also discards records added through DDNS.

Treat zones using allow-update or update-policy as dynamic. Create their files when missing, but preserve existing files and journals on subsequent runs.

Track the dynamic state in the role cache so conversion to a static zone remains explicit. During conversion, freeze the zone, discard its journal, render only records declared in bind_zones, install the static configuration, and reload BIND. Attempt to thaw frozen zones if reconciliation fails.

Add regression coverage and document both lifecycle behaviors.

Fixes #39.

Assisted-by: Codex:gpt-5.6  
Tested-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>
Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>